### PR TITLE
Fix colnames

### DIFF
--- a/beta=1.0e+04-Am=0.25-Rm=inf.dat
+++ b/beta=1.0e+04-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0208e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.02561442e-04			6.80058660e-06			5.73555414e+00			-1.11248000e+00						1.66695700e+00							2.58796626e-03					-5.02662342e-04						-2.20423924e-02						inf						inf			
 1.52081200e-01			1.01763758e-04			6.67552768e-06			5.70168410e+00			-1.10609000e+00						1.65387600e+00							2.57464448e-03					-5.00780992e-04						-2.19801926e-02						inf						inf			
 1.53468700e-01			1.01129364e-04			6.56463474e-06			5.66985700e+00			-1.10299500e+00						1.64172600e+00							2.55761810e-03					-4.98940734e-04						-2.19476716e-02						inf						inf			

--- a/beta=1.0e+04-Am=0.5-Rm=inf.dat
+++ b/beta=1.0e+04-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0231e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.50959936e-04			1.00193860e-05			5.08457648e+00			-9.77756324e-01						1.59798038e+00							2.60465660e-03					-5.01045856e-04						-2.50647298e-02						inf						inf			
 1.52081200e-01			1.49829642e-04			9.84086636e-06			5.05446422e+00			-9.71932956e-01						1.58587200e+00							2.59197316e-03					-4.99199684e-04						-2.49966186e-02						inf						inf			
 1.53468700e-01			1.48902574e-04			9.67626466e-06			5.02492808e+00			-9.69112836e-01						1.57412334e+00							2.57486674e-03					-4.97394444e-04						-2.49612550e-02						inf						inf			

--- a/beta=1.0e+04-Am=1-Rm=1.dat
+++ b/beta=1.0e+04-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0161e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.43946598e-04			9.55232886e-06			5.33985766e+00			-1.02461638e+00						1.63084454e+00							2.98756174e-03					-5.90789358e-04						-2.51660622e-02						inf						inf			
 1.52081200e-01			1.42857086e-04			9.38055706e-06			5.30816270e+00			-1.01857524e+00						1.61826450e+00							2.97188446e-03					-5.88435388e-04						-2.50968430e-02						inf						inf			
 1.53468700e-01			1.41970280e-04			9.22383832e-06			5.27742810e+00			-1.01565738e+00						1.60620912e+00							2.95106596e-03					-5.86131262e-04						-2.50610844e-02						inf						inf			

--- a/beta=1.0e+04-Am=1-Rm=10.dat
+++ b/beta=1.0e+04-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0192e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.78224326e-04			1.18377900e-05			4.67749200e+00			-8.89210448e-01						1.56091500e+00							2.56881300e-03					-4.92802872e-04						-2.61728000e-02						inf						inf			
 1.52081200e-01			1.76935600e-04			1.16327578e-05			4.64961900e+00			-8.83739000e-01						1.54941800e+00							2.55668724e-03					-4.90972142e-04						-2.61037700e-02						inf						inf			
 1.53468700e-01			1.75851552e-04			1.14375308e-05			4.62127646e+00			-8.81090700e-01						1.53784900e+00							2.53956702e-03					-4.89182016e-04						-2.60682700e-02						inf						inf			

--- a/beta=1.0e+04-Am=1-Rm=100.dat
+++ b/beta=1.0e+04-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0250e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.25822836e-04			1.50050400e-05			4.42176300e+00			-8.35862744e-01						1.53608900e+00							2.59642402e-03					-4.91242122e-04						-2.87016700e-02						inf						inf			
 1.52081200e-01			2.24227000e-04			1.47499542e-05			4.39532526e+00			-8.30611894e-01						1.52501800e+00							2.58476400e-03					-4.89475714e-04						-2.86274924e-02						inf						inf			
 1.53468700e-01			2.22864000e-04			1.45022200e-05			4.36783400e+00			-8.28067396e-01						1.51362000e+00							2.56780700e-03					-4.87749402e-04						-2.85895070e-02						inf						inf			

--- a/beta=1.0e+04-Am=1-Rm=inf.dat
+++ b/beta=1.0e+04-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0271e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.35880792e-04			1.56733734e-05			4.41490692e+00			-8.34680128e-01						1.53546356e+00							2.63963784e-03					-4.98989728e-04						-2.93141966e-02						inf						inf			
 1.52081200e-01			2.34214494e-04			1.54070164e-05			4.38851194e+00			-8.29435262e-01						1.52440306e+00							2.62781386e-03					-4.97200432e-04						-2.92384868e-02						inf						inf			
 1.53468700e-01			2.32790868e-04			1.51482326e-05			4.36105250e+00			-8.26893482e-01						1.51301024e+00							2.61060804e-03					-4.95451816e-04						-2.91997092e-02						inf						inf			

--- a/beta=1.0e+04-Am=2-Rm=inf.dat
+++ b/beta=1.0e+04-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0352e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.96286752e-04			2.63654620e-05			3.77295438e+00			-6.90528980e-01						1.47704998e+00							2.69446472e-03					-4.93056154e-04						-3.55483430e-02						inf						inf			
 1.52081200e-01			3.93721890e-04			2.59468658e-05			3.74990838e+00			-6.85839758e-01						1.46716940e+00							2.68386832e-03					-4.91378742e-04						-3.54619616e-02						inf						inf			
 1.53468700e-01			3.91425830e-04			2.55133436e-05			3.72407948e+00			-6.83560076e-01						1.45619474e+00							2.66677128e-03					-4.89741298e-04						-3.54187082e-02						inf						inf			

--- a/beta=1.0e+05-Am=0.25-Rm=inf.dat
+++ b/beta=1.0e+05-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0016e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.67672490e-05			2.44591222e-06			3.89614638e+00			-7.14557786e-01						1.47743378e+00							8.73416000e-04					-1.60140910e-04						-1.09067748e-02						inf						inf			
 1.52081200e-01			3.65255096e-05			2.40656262e-06			3.87245044e+00			-7.09758194e-01						1.46741104e+00							8.69930290e-04					-1.59594352e-04						-1.08797820e-02						inf						inf			
 1.53468700e-01			3.63117212e-05			2.36637792e-06			3.84630752e+00			-7.07424682e-01						1.45645530e+00							8.64413062e-04					-1.59060774e-04						-1.08662302e-02						inf						inf			

--- a/beta=1.0e+05-Am=0.5-Rm=inf.dat
+++ b/beta=1.0e+05-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0023e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.18605382e-05			3.45260735e-06			3.51896886e+00			-6.28701724e-01						1.44181710e+00							8.83237298e-04					-1.57745516e-04						-1.24292861e-02						inf						inf			
 1.52081200e-01			5.15415155e-05			3.39977273e-06			3.49718290e+00			-6.24235388e-01						1.43256400e+00							8.80057602e-04					-1.57231188e-04						-1.23997629e-02						inf						inf			
 1.53468700e-01			5.12512492e-05			3.34350514e-06			3.47190898e+00			-6.22057651e-01						1.42192233e+00							8.74635794e-04					-1.56729578e-04						-1.23852039e-02						inf						inf			

--- a/beta=1.0e+05-Am=1-Rm=1.dat
+++ b/beta=1.0e+05-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0002e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.69140570e-05			2.45624660e-06			3.81827618e+00			-6.94667368e-01						1.47331756e+00							8.81494346e-04					-1.62193082e-04						-1.08534326e-02						inf						inf			
 1.52081200e-01			3.66752378e-05			2.41720872e-06			3.79492596e+00			-6.89935256e-01						1.46342920e+00							8.77961368e-04					-1.61626022e-04						-1.08268022e-02						inf						inf			
 1.53468700e-01			3.64623694e-05			2.37691388e-06			3.76883314e+00			-6.87636110e-01						1.45248198e+00							8.72274746e-04					-1.61072256e-04						-1.08135044e-02						inf						inf			

--- a/beta=1.0e+05-Am=1-Rm=10.dat
+++ b/beta=1.0e+05-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0006e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.57555146e-05			3.71311102e-06			3.39812300e+00			-5.98718100e-01						1.42852400e+00							8.77146296e-04					-1.55364326e-04						-1.26997500e-02						inf						inf			
 1.52081200e-01			5.54224416e-05			3.65747166e-06			3.37689900e+00			-5.94358400e-01						1.41956700e+00							8.74093262e-04					-1.54860400e-04						-1.26699700e-02						inf						inf			
 1.53468700e-01			5.51167094e-05			3.59728194e-06			3.35180000e+00			-5.92230200e-01						1.40906500e+00							8.68728328e-04					-1.54369006e-04						-1.26554098e-02						inf						inf			

--- a/beta=1.0e+05-Am=1-Rm=100.dat
+++ b/beta=1.0e+05-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0020e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			7.06691616e-05			4.70794824e-06			3.23205500e+00			-5.59879966e-01						1.40608500e+00							8.82754396e-04					-1.53015564e-04						-1.39772444e-02						inf						inf			
 1.52081200e-01			7.02632916e-05			4.63933464e-06			3.21165932e+00			-5.55670986e-01						1.39756600e+00							8.79923670e-04					-1.52543004e-04						-1.39450762e-02						inf						inf			
 1.53468700e-01			6.98871598e-05			4.56369718e-06			3.18694682e+00			-5.53610022e-01						1.38732800e+00							8.74730756e-04					-1.52082752e-04						-1.39295090e-02						inf						inf			

--- a/beta=1.0e+05-Am=1-Rm=inf.dat
+++ b/beta=1.0e+05-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0035e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			7.33331306e-05			4.88593924e-06			3.18691300e+00			-5.48941566e-01						1.39914674e+00							8.73220944e-04					-1.50503874e-04						-1.41424424e-02						inf						inf			
 1.52081200e-01			7.29171024e-05			4.81532894e-06			3.16673812e+00			-5.44774308e-01						1.39075662e+00							8.70482076e-04					-1.50044416e-04						-1.41100560e-02						inf						inf			
 1.53468700e-01			7.25306962e-05			4.73707618e-06			3.14212146e+00			-5.42732008e-01						1.38060214e+00							8.65393744e-04					-1.49597052e-04						-1.40944380e-02						inf						inf			

--- a/beta=1.0e+05-Am=2-Rm=inf.dat
+++ b/beta=1.0e+05-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0064e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.12983020e-04			7.53165600e-06			2.92517796e+00			-4.87701467e-01						1.35171429e+00							8.84012922e-04					-1.47389349e-04						-1.67960876e-02						inf						inf			
 1.52081200e-01			1.12386963e-04			7.42802704e-06			2.90635094e+00			-4.83785786e-01						1.34409647e+00							8.81611476e-04					-1.46970006e-04						-1.67587629e-02						inf						inf			
 1.53468700e-01			1.11828055e-04			7.30979914e-06			2.88246347e+00			-4.81856188e-01						1.33450496e+00							8.76793290e-04					-1.46562486e-04						-1.67411837e-02						inf						inf			

--- a/beta=1.0e+05-Am=4-Rm=inf.dat
+++ b/beta=1.0e+05-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0117e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.80029731e-04			1.20057008e-05			2.63211847e+00			-4.24031876e-01						1.29883039e+00							8.71715071e-04					-1.40470635e-04						-2.01426969e-02						inf						inf			
 1.52081200e-01			1.79159484e-04			1.18498431e-05			2.61487614e+00			-4.20417524e-01						1.29202073e+00							8.69716398e-04					-1.40101300e-04						-2.00998510e-02						inf						inf			
 1.53468700e-01			1.78335773e-04			1.16661451e-05			2.59199927e+00			-4.18627522e-01						1.28305061e+00							8.65314863e-04					-1.39743261e-04						-2.00803294e-02						inf						inf			

--- a/beta=1.1e+03-Am=0.25-Rm=inf.dat
+++ b/beta=1.1e+03-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0531e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.73817008e-04			1.80807558e-05			8.37700266e+00			-1.66865510e+00						2.01625670e+00							7.82535750e-03					-1.57692816e-03						-4.64202090e-02						inf						inf			
 1.52081200e-01			2.71488516e-04			1.77237026e-05			8.32777158e+00			-1.65996722e+00						1.99884262e+00							7.77822032e-03					-1.57063712e-03						-4.62799148e-02						inf						inf			
 1.53468700e-01			2.69767428e-04			1.74365880e-05			8.28611452e+00			-1.65575976e+00						1.98431654e+00							7.72569758e-03					-1.56447700e-03						-4.62063738e-02						inf						inf			

--- a/beta=1.1e+03-Am=0.5-Rm=inf.dat
+++ b/beta=1.1e+03-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0614e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			4.40158100e-04			2.91024900e-05			7.27244300e+00			-1.44701500e+00						1.85977500e+00							7.77061300e-03					-1.55582900e-03						-5.31322800e-02						inf						inf			
 1.52081200e-01			4.36488500e-04			2.85370500e-05			7.22983000e+00			-1.43932300e+00						1.84414100e+00							7.72552300e-03					-1.54971600e-03						-5.29750000e-02						inf						inf			
 1.53468700e-01			4.33718700e-04			2.80698600e-05			7.19276700e+00			-1.43560400e+00						1.83072200e+00							7.67352300e-03					-1.54373200e-03						-5.28921100e-02						inf						inf			

--- a/beta=1.1e+03-Am=1-Rm=10.dat
+++ b/beta=1.1e+03-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0563e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.81305124e-04			3.84835400e-05			6.48313400e+00			-1.28038400e+00						1.76196900e+00							7.66803400e-03					-1.54087100e-03						-5.66662932e-02						inf						inf			
 1.52081200e-01			5.76585720e-04			3.77519600e-05			6.44509900e+00			-1.27338400e+00						1.74751900e+00							7.62434450e-03					-1.53470400e-03						-5.65028200e-02						inf						inf			
 1.53468700e-01			5.72933700e-04			3.71280000e-05			6.41087600e+00			-1.27000300e+00						1.73468200e+00							7.57176500e-03					-1.52866600e-03						-5.64170500e-02						inf						inf			

--- a/beta=1.1e+03-Am=1-Rm=inf.dat
+++ b/beta=1.1e+03-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0750e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			7.31575300e-04			4.84427000e-05			6.22137500e+00			-1.23061700e+00						1.72913700e+00							7.77103770e-03					-1.54235000e-03						-6.19593600e-02						inf						inf			
 1.52081200e-01			7.25676700e-04			4.75273000e-05			6.18494300e+00			-1.22384400e+00						1.71511300e+00							7.72826700e-03					-1.53638400e-03						-6.17821100e-02						inf						inf			
 1.53468700e-01			7.21081000e-04			4.67397400e-05			6.15186700e+00			-1.22057200e+00						1.70253400e+00							7.67622000e-03					-1.53054500e-03						-6.16887700e-02						inf						inf			

--- a/beta=1.1e+03-Am=2-Rm=inf.dat
+++ b/beta=1.1e+03-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.1001e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.30651600e-03			8.66653800e-05			5.17196600e+00			-1.00779300e+00						1.61824200e+00							7.83796500e-03					-1.53067200e-03						-7.47987000e-02						inf						inf			
 1.52081200e-01			1.29657100e-03			8.51039432e-05			5.14151600e+00			-1.00191600e+00						1.60580500e+00							7.79832000e-03					-1.52489300e-03						-7.45959200e-02						inf						inf			
 1.53468700e-01			1.28844300e-03			8.36763390e-05			5.11196500e+00			-9.99076300e-01						1.59386600e+00							7.74583622e-03					-1.51924000e-03						-7.44901700e-02						inf						inf			

--- a/beta=1.1e+03-Am=4-Rm=inf.dat
+++ b/beta=1.1e+03-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.1488e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.53502700e-03			1.68480078e-04			4.18940700e+00			-7.90202300e-01						1.52667200e+00							7.97454808e-03					-1.50722700e-03						-9.44856910e-02						inf						inf			
 1.52081200e-01			2.51748156e-03			1.65667700e-04			4.16426000e+00			-7.85158400e-01						1.51587100e+00							7.93941300e-03					-1.50180700e-03						-9.42479546e-02						inf						inf			
 1.53468700e-01			2.50221094e-03			1.62877040e-04			4.13748200e+00			-7.82715898e-01						1.50447900e+00							7.88686100e-03					-1.49651100e-03						-9.41267144e-02						inf						inf			

--- a/beta=1.1e+04-Am=4-Rm=inf.dat
+++ b/beta=1.1e+04-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.0513e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			6.94080138e-04			4.62339010e-05			3.26658290e+00			-5.69111582e-01						1.41475126e+00							2.73278354e-03					-4.76117898e-04						-4.41136690e-02						inf						inf			
 1.52081200e-01			6.90053280e-04			4.55555378e-05			3.24601558e+00			-5.64870200e-01						1.40612582e+00							2.72384718e-03					-4.74634624e-04						-4.40119566e-02						inf						inf			
 1.53468700e-01			6.86325532e-04			4.48106878e-05			3.22122378e+00			-5.62793568e-01						1.39581328e+00							2.70762586e-03					-4.73189630e-04						-4.39625280e-02						inf						inf			

--- a/beta=1.2e+02-Am=1-Rm=inf.dat
+++ b/beta=1.2e+02-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.2341e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.99593200e-03			1.31538700e-04			9.02058200e+00			-1.83078500e+00						2.08723400e+00							2.37369050e-02					-4.94885566e-03						-1.31857000e-01						inf						inf			
 1.52081200e-01			1.97845700e-03			1.28886400e-04			8.96802418e+00			-1.82162500e+00						2.06862864e+00							2.35823258e-02					-4.92789362e-03						-1.31458600e-01						inf						inf			
 1.53468700e-01			1.96577800e-03			1.26810800e-04			8.92487998e+00			-1.81720000e+00						2.05358100e+00							2.34176970e-02					-4.90735316e-03						-1.31249900e-01						inf						inf			

--- a/beta=1.3e+02-Am=2-Rm=inf.dat
+++ b/beta=1.3e+02-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.3258e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.99737600e-03			2.64065900e-04			7.23468600e+00			-1.46377100e+00						1.85147000e+00							2.32383200e-02					-4.77935000e-03						-1.59522700e-01						inf						inf			
 1.52081200e-01			3.96347900e-03			2.58878900e-04			7.19268000e+00			-1.45618600e+00						1.83567100e+00							2.30962600e-02					-4.75967900e-03						-1.59055300e-01						inf						inf			
 1.53468700e-01			3.93798500e-03			2.54629500e-04			7.15655100e+00			-1.45253200e+00						1.82226200e+00							2.29357300e-02					-4.74041100e-03						-1.58808200e-01						inf						inf			

--- a/beta=1.3e+06-Am=1-Rm=inf.dat
+++ b/beta=1.3e+06-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.2550e+06
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.12473528e-05			1.41730642e-06			2.43091780e+00			-3.79160108e-01						1.26007724e+00							2.58711248e-04					-4.03234380e-05						-6.65992810e-03						inf						inf			
 1.52081200e-01			2.11525946e-05			1.39980890e-06			2.41473788e+00			-3.75757786e-01						1.25386792e+00							2.58216980e-04					-4.02265520e-05						-6.64621458e-03						inf						inf			
 1.53468700e-01			2.10629150e-05			1.37868020e-06			2.39249508e+00			-3.74067474e-01						1.24539134e+00							2.57019868e-04					-4.01329062e-05						-6.64014788e-03						inf						inf			

--- a/beta=1.5e+02-Am=4-Rm=inf.dat
+++ b/beta=1.5e+02-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.4813e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			8.33722400e-03			5.52211700e-04			5.69485100e+00			-1.13401000e+00						1.67955300e+00							2.30451900e-02					-4.63639800e-03						-1.99600000e-01						inf						inf			
 1.52081200e-01			8.27075848e-03			5.41908200e-04			5.66165400e+00			-1.12772300e+00						1.66610300e+00							2.29177700e-02					-4.61797900e-03						-1.99047300e-01						inf						inf			
 1.53468700e-01			8.21783000e-03			5.32832600e-04			5.63078200e+00			-1.12469600e+00						1.65373900e+00							2.27587900e-02					-4.59994700e-03						-1.98756700e-01						inf						inf			

--- a/beta=1.6e+07-Am=1-Rm=inf.dat
+++ b/beta=1.6e+07-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=1.5721e+07
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			6.30281400e-06			4.20539228e-07			1.81347918e+00			-2.51897438e-01						1.13765260e+00							7.35821768e-05					-1.02133474e-05						-3.18897178e-03						inf						inf			
 1.52081200e-01			6.28289934e-06			4.16250444e-07			1.80072924e+00			-2.49203598e-01						1.13330146e+00							7.35963034e-05					-1.01966794e-05						-3.18327796e-03						inf						inf			
 1.53468700e-01			6.26516196e-06			4.10676674e-07			1.78092758e+00			-2.47853784e-01						1.12658756e+00							7.33719656e-05					-1.01810842e-05						-3.18107500e-03						inf						inf			

--- a/beta=2.2e+03-Am=0.25-Rm=inf.dat
+++ b/beta=2.2e+03-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2394e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.01370000e-04			1.33172800e-05			7.34972800e+00			-1.45375400e+00						1.87231400e+00							5.39484300e-03					-1.07357100e-03						-3.62141298e-02						inf						inf			
 1.52081200e-01			1.99698700e-04			1.30592500e-05			7.30651100e+00			-1.44596900e+00						1.85661700e+00							5.36387500e-03					-1.06938800e-03						-3.61064800e-02						inf						inf			
 1.53468700e-01			1.98436900e-04			1.28457200e-05			7.26882900e+00			-1.44220100e+00						1.84311200e+00							5.32796800e-03					-1.06529400e-03						-3.60498700e-02						inf						inf			

--- a/beta=2.2e+03-Am=1-Rm=1.dat
+++ b/beta=2.2e+03-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2202e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.99470300e-04			1.32053700e-05			7.08252700e+00			-1.38021400e+00						1.84139400e+00							5.78717100e-03					-1.19172600e-03						-3.51623200e-02						inf						inf			
 1.52081200e-01			1.97845700e-04			1.29531900e-05			7.04058300e+00			-1.37265900e+00						1.82598400e+00							5.75191100e-03					-1.18658400e-03						-3.50594800e-02						inf						inf			
 1.53468700e-01			1.96600200e-04			1.27403500e-05			7.00317800e+00			-1.36901000e+00						1.81244000e+00							5.70984800e-03					-1.18154600e-03						-3.50065700e-02						inf						inf			

--- a/beta=2.2e+03-Am=1-Rm=10.dat
+++ b/beta=2.2e+03-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2390e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.91461786e-04			2.59460800e-05			5.82879700e+00			-1.13923300e+00						1.68450000e+00							5.31933076e-03					-1.05419800e-03						-4.35997500e-02						inf						inf			
 1.52081200e-01			3.88383652e-04			2.54653634e-05			5.79449000e+00			-1.13278500e+00						1.67111400e+00							5.29063500e-03					-1.05007300e-03						-4.34769800e-02						inf						inf			
 1.53468700e-01			3.85941718e-04			2.50416600e-05			5.76249200e+00			-1.12967000e+00						1.65877700e+00							5.25444218e-03					-1.04603600e-03						-4.34127900e-02						inf						inf			

--- a/beta=2.2e+04-Am=0.25-Rm=inf.dat
+++ b/beta=2.2e+04-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1840e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			7.26329572e-05			4.82165692e-06			5.05749106e+00			-9.67972230e-01						1.59165332e+00							1.79843568e-03					-3.44353834e-04						-1.73075994e-02						inf						inf			
 1.52081200e-01			7.20922176e-05			4.73607900e-06			5.02747514e+00			-9.62165040e-01						1.57965052e+00							1.78978302e-03					-3.43093570e-04						-1.72605256e-02						inf						inf			
 1.53468700e-01			7.16481770e-05			4.65694406e-06			4.99792406e+00			-9.59350610e-01						1.56796100e+00							1.77803620e-03					-3.41861412e-04						-1.72361260e-02						inf						inf			

--- a/beta=2.2e+04-Am=0.5-Rm=inf.dat
+++ b/beta=2.2e+04-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1873e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.05771342e-04			7.02780456e-06			4.49288874e+00			-8.48946448e-01						1.53824962e+00							1.81779634e-03					-3.43406836e-04						-1.97411368e-02						inf						inf			
 1.52081200e-01			1.05020054e-04			6.90776872e-06			4.46603992e+00			-8.43630508e-01						1.52711554e+00							1.80962174e-03					-3.42176790e-04						-1.96896876e-02						inf						inf			
 1.53468700e-01			1.04382042e-04			6.79190574e-06			4.43830450e+00			-8.41053110e-01						1.51572912e+00							1.79781800e-03					-3.40974746e-04						-1.96633100e-02						inf						inf			

--- a/beta=2.2e+04-Am=1-Rm=1.dat
+++ b/beta=2.2e+04-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1773e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.01790712e-04			6.76203454e-06			4.70226242e+00			-8.89057482e-01						1.56332740e+00							2.04350134e-03					-3.95193070e-04						-1.98223856e-02						inf						inf			
 1.52081200e-01			1.01057282e-04			6.64516986e-06			4.67416002e+00			-8.83561674e-01						1.55180510e+00							2.03365470e-03					-3.93680020e-04						-1.97699710e-02						inf						inf			
 1.53468700e-01			1.00440013e-04			6.53374888e-06			4.64553000e+00			-8.80903722e-01						1.54019280e+00							2.01970958e-03					-3.92199980e-04						-1.97431188e-02						inf						inf			

--- a/beta=2.2e+04-Am=1-Rm=10.dat
+++ b/beta=2.2e+04-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1808e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.21124726e-04			8.05295534e-06			4.17913486e+00			-7.78900846e-01						1.51184200e+00							1.79205400e-03					-3.36502800e-04						-2.04804248e-02						inf						inf			
 1.52081200e-01			1.20295948e-04			7.91941818e-06			4.15394300e+00			-7.73857000e-01						1.50122100e+00							1.78428500e-03					-3.35295122e-04						-2.04285300e-02						inf						inf			
 1.53468700e-01			1.19575812e-04			7.78658870e-06			4.12700900e+00			-7.71411390e-01						1.48997700e+00							1.77254800e-03					-3.34115052e-04						-2.04022044e-02						inf						inf			

--- a/beta=2.2e+04-Am=1-Rm=100.dat
+++ b/beta=2.2e+04-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1887e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.53688810e-04			1.02219934e-05			3.94504782e+00			-7.28383200e-01						1.48964300e+00							1.81202600e-03					-3.34800058e-04						-2.25072600e-02						inf						inf			
 1.52081200e-01			1.52667936e-04			1.00563900e-05			3.92111500e+00			-7.23543300e-01						1.47945300e+00							1.80461808e-03					-3.33640970e-04						-2.24515000e-02						inf						inf			
 1.53468700e-01			1.51766524e-04			9.88802290e-06			3.89486800e+00			-7.21192700e-01						1.46838100e+00							1.79302132e-03					-3.32509100e-04						-2.24234030e-02						inf						inf			

--- a/beta=2.2e+04-Am=1-Rm=inf.dat
+++ b/beta=2.2e+04-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.1932e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.62827530e-04			1.08299550e-05			3.93289744e+00			-7.25971974e-01						1.48854432e+00							1.84944278e-03					-3.41228620e-04						-2.31377896e-02						inf						inf			
 1.52081200e-01			1.61747416e-04			1.06546918e-05			3.90903342e+00			-7.21142760e-01						1.47837606e+00							1.84191718e-03					-3.40052208e-04						-2.30805434e-02						inf						inf			
 1.53468700e-01			1.60792966e-04			1.04763254e-05			3.88282994e+00			-7.18796994e-01						1.46731386e+00							1.83011504e-03					-3.38903492e-04						-2.30517042e-02						inf						inf			

--- a/beta=2.2e+04-Am=2-Rm=inf.dat
+++ b/beta=2.2e+04-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2054e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.64722874e-04			1.76264812e-05			3.43690048e+00			-6.10301388e-01						1.43756904e+00							1.88554564e-03					-3.34670372e-04						-2.78796958e-02						inf						inf			
 1.52081200e-01			2.63121912e-04			1.73601652e-05			3.41550884e+00			-6.05907192e-01						1.42848384e+00							1.87892312e-03					-3.33591608e-04						-2.78142174e-02						inf						inf			
 1.53468700e-01			2.61654958e-04			1.70735810e-05			3.39037922e+00			-6.03762388e-01						1.41790110e+00							1.86741762e-03					-3.32539838e-04						-2.77820366e-02						inf						inf			

--- a/beta=2.2e+04-Am=4-Rm=inf.dat
+++ b/beta=2.2e+04-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2291e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			4.42312420e-04			2.94775082e-05			3.05486512e+00			-5.18247846e-01						1.37657716e+00							1.88768080e-03					-3.20145604e-04						-3.40023190e-02						inf						inf			
 1.52081200e-01			4.39888072e-04			2.90614398e-05			3.03536806e+00			-5.14205548e-01						1.36857794e+00							1.88215120e-03					-3.19201276e-04						-3.39256366e-02						inf						inf			
 1.53468700e-01			4.37624352e-04			2.85936628e-05			3.01111596e+00			-5.12217954e-01						1.35870538e+00							1.87149698e-03					-3.18282622e-04						-3.38890398e-02						inf						inf			

--- a/beta=2.3e+03-Am=0.5-Rm=inf.dat
+++ b/beta=2.3e+03-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2508e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.10261500e-04			2.05425200e-05			6.45565300e+00			-1.27248600e+00						1.75531400e+00							5.38702300e-03					-1.06508600e-03						-4.12374100e-02						inf						inf			
 1.52081200e-01			3.07750300e-04			2.01527200e-05			6.41774900e+00			-1.26549400e+00						1.74100900e+00							5.35734500e-03					-1.06098900e-03						-4.11180300e-02						inf						inf			
 1.53468700e-01			3.05808100e-04			1.98200200e-05			6.38361000e+00			-1.26211100e+00						1.72828300e+00							5.32151500e-03					-1.05698000e-03						-4.10552100e-02						inf						inf			

--- a/beta=2.3e+03-Am=1-Rm=100.dat
+++ b/beta=2.3e+03-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2670e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			4.90139900e-04			3.24958300e-05			5.57083900e+00			-1.08846900e+00						1.65490700e+00							5.38111800e-03					-1.05386900e-03						-4.75481200e-02						inf						inf			
 1.52081200e-01			4.86327900e-04			3.18993436e-05			5.53807300e+00			-1.08224400e+00						1.64193100e+00							5.35314400e-03					-1.04987300e-03						-4.74158200e-02						inf						inf			
 1.53468700e-01			4.83275100e-04			3.13672086e-05			5.50711124e+00			-1.07923400e+00						1.62980900e+00							5.31728100e-03					-1.04596400e-03						-4.73465800e-02						inf						inf			

--- a/beta=2.3e+03-Am=1-Rm=inf.dat
+++ b/beta=2.3e+03-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.2699e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.01352506e-04			3.32394700e-05			5.55972100e+00			-1.08641200e+00						1.65363100e+00							5.41312962e-03					-1.05937000e-03						-4.80354500e-02						inf						inf			
 1.52081200e-01			4.97454838e-04			3.26295500e-05			5.52702400e+00			-1.08019600e+00						1.64067300e+00							5.38504814e-03					-1.05536200e-03						-4.79018700e-02						inf						inf			
 1.53468700e-01			4.94332238e-04			3.20851672e-05			5.49611100e+00			-1.07719000e+00						1.62856000e+00							5.34902500e-03					-1.05144100e-03						-4.78319500e-02						inf						inf			

--- a/beta=2.3e+03-Am=2-Rm=inf.dat
+++ b/beta=2.3e+03-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.3068e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			8.78688162e-04			5.83494166e-05			4.64776100e+00			-8.90609000e-01						1.56480300e+00							5.48578168e-03					-1.05224800e-03						-5.81480300e-02						inf						inf			
 1.52081200e-01			8.72302298e-04			5.73362416e-05			4.62015900e+00			-8.85171600e-01						1.55325500e+00							5.45995578e-03					-1.04838400e-03						-5.79956894e-02						inf						inf			
 1.53468700e-01			8.66921018e-04			5.63716802e-05			4.59211996e+00			-8.82541200e-01						1.54164300e+00							5.42363578e-03					-1.04460700e-03						-5.79170764e-02						inf						inf			

--- a/beta=2.3e+05-Am=1-Rm=inf.dat
+++ b/beta=2.3e+05-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.3286e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			4.97824764e-05			3.31859364e-06			2.93417368e+00			-4.89255368e-01						1.35336470e+00							5.98734856e-04					-9.97581030e-05						-1.11663494e-02						inf						inf			
 1.52081200e-01			4.95195392e-05			3.27289080e-06			2.91528902e+00			-4.85329786e-01						1.34572384e+00							5.97110952e-04					-9.94751614e-05						-1.11414950e-02						inf						inf			
 1.53468700e-01			4.92730942e-05			3.22078402e-06			2.89134812e+00			-4.83395924e-01						1.33611164e+00							5.93853914e-04					-9.92002090e-05						-1.11297812e-02						inf						inf			

--- a/beta=2.4e+03-Am=4-Rm=inf.dat
+++ b/beta=2.4e+03-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.3794e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.66380958e-03			1.10674606e-04			3.82194900e+00			-7.03886968e-01						1.48811700e+00							5.60106828e-03					-1.03267300e-03						-7.34782734e-02						inf						inf			
 1.52081200e-01			1.65292590e-03			1.08904638e-04			3.79866400e+00			-6.99156488e-01						1.47807900e+00							5.57850856e-03					-1.02910800e-03						-7.32993816e-02						inf						inf			
 1.53468700e-01			1.64320164e-03			1.07080422e-04			3.77272800e+00			-6.96858900e-01						1.46700000e+00							5.54251330e-03					-1.02562746e-03						-7.32094882e-02						inf						inf			

--- a/beta=2.5e+02-Am=1-Rm=inf.dat
+++ b/beta=2.5e+02-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.4918e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.48681100e-03			9.81620600e-05			7.86536000e+00			-1.58617100e+00						1.93414000e+00							1.61862200e-02					-3.30995200e-03						-1.03046900e-01						inf						inf			
 1.52081200e-01			1.47409700e-03			9.62183900e-05			7.81951900e+00			-1.57800900e+00						1.91744100e+00							1.60867900e-02					-3.29646300e-03						-1.02739600e-01						inf						inf			
 1.53468700e-01			1.46466500e-03			9.46515400e-05			7.78071600e+00			-1.57406800e+00						1.90349900e+00							1.59764500e-02					-3.28325100e-03						-1.02577400e-01						inf						inf			

--- a/beta=2.6e+02-Am=2-Rm=inf.dat
+++ b/beta=2.6e+02-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.6152e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.82297500e-03			1.86780100e-04			6.42521400e+00			-1.28579700e+00						1.75624900e+00							1.60872100e-02					-3.24671600e-03						-1.24343600e-01						inf						inf			
 1.52081200e-01			2.79980000e-03			1.83204600e-04			6.38778900e+00			-1.27888100e+00						1.74176300e+00							1.59949000e-02					-3.23379300e-03						-1.23987200e-01						inf						inf			
 1.53468700e-01			2.78189800e-03			1.80169800e-04			6.35434100e+00			-1.27554700e+00						1.72897500e+00							1.58851900e-02					-3.22114000e-03						-1.23799000e-01						inf						inf			

--- a/beta=2.8e+02-Am=4-Rm=inf.dat
+++ b/beta=2.8e+02-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.8397e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.69452548e-03			3.77665002e-04			5.11763530e+00			-1.00302210e+00						1.62000410e+00							1.61595754e-02					-3.18611068e-03						-1.55860854e-01						inf						inf			
 1.52081200e-01			5.65103376e-03			3.70854512e-04			5.08757916e+00			-9.97205538e-01						1.60752482e+00							1.60764140e-02					-3.17385908e-03						-1.55441958e-01						inf						inf			
 1.53468700e-01			5.61534332e-03			3.64612660e-04			5.05835708e+00			-9.94400484e-01						1.59552276e+00							1.59664098e-02					-3.16187130e-03						-1.55223356e-01						inf						inf			

--- a/beta=2.9e+06-Am=1-Rm=inf.dat
+++ b/beta=2.9e+06-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=2.9144e+06
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.40450700e-05			9.37040954e-07			2.20919618e+00			-3.32215914e-01						1.21707304e+00							1.70001642e-04					-2.55484582e-05						-5.18211662e-03						inf						inf			
 1.52081200e-01			1.39884054e-05			9.26145684e-07			2.19422810e+00			-3.29058526e-01						1.21151960e+00							1.69745564e-04					-2.54934374e-05						-5.17190154e-03						inf						inf			
 1.53468700e-01			1.39351080e-05			9.12636806e-07			2.17279858e+00			-3.27484558e-01						1.20362236e+00							1.69040148e-04					-2.54404778e-05						-5.16755514e-03						inf						inf			

--- a/beta=3.7e+07-Am=1-Rm=inf.dat
+++ b/beta=3.7e+07-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=3.6517e+07
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			4.28329384e-06			2.85772136e-07			1.63637626e+00			-2.17702678e-01						1.10109068e+00							4.85237974e-05					-6.45203146e-06						-2.52346238e-03						inf						inf			
 1.52081200e-01			4.27168506e-06			2.83059280e-07			1.62465062e+00			-2.15227924e-01						1.09729050e+00							4.85397220e-05					-6.44356232e-06						-2.51920552e-03						inf						inf			
 1.53468700e-01			4.26202222e-06			2.79462526e-07			1.60568230e+00			-2.13986894e-01						1.09118268e+00							4.84207118e-05					-6.43578196e-06						-2.51764988e-03						inf						inf			

--- a/beta=4.7e+03-Am=1-Rm=1.dat
+++ b/beta=4.7e+03-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7490e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.52850888e-04			1.01307802e-05			6.20323112e+00			-1.20189740e+00						1.73003586e+00							3.99449944e-03					-8.07456974e-04						-2.82650108e-02						inf						inf			
 1.52081200e-01			1.51642514e-04			9.94196114e-06			6.16649826e+00			-1.19511104e+00						1.71607172e+00							3.97169788e-03					-8.04098816e-04						-2.81842546e-02						inf						inf			
 1.53468700e-01			1.50692204e-04			9.77720600e-06			6.13256702e+00			-1.19183450e+00						1.70334172e+00							3.94323714e-03					-8.00809700e-04						-2.81424742e-02						inf						inf			

--- a/beta=4.7e+04-Am=0.25-Rm=inf.dat
+++ b/beta=4.7e+04-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6760e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.16860872e-05			3.43483114e-06			4.44392620e+00			-8.35631780e-01						1.52971078e+00							1.25413156e-03					-2.35792962e-04						-1.37031168e-02						inf						inf			
 1.52081200e-01			5.13218074e-05			3.37649036e-06			4.41731272e+00			-8.30354438e-01						1.51870998e+00							1.24857494e-03					-2.34954550e-04						-1.36674636e-02						inf						inf			
 1.53468700e-01			5.10116844e-05			3.31992228e-06			4.38966682e+00			-8.27794022e-01						1.50739664e+00							1.24047960e-03					-2.34135322e-04						-1.36492268e-02						inf						inf			

--- a/beta=4.7e+04-Am=0.5-Rm=inf.dat
+++ b/beta=4.7e+04-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6810e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			7.45557918e-05			4.95878286e-06			3.96817050e+00			-7.32307338e-01						1.48779082e+00							1.27283854e-03					-2.34773358e-04						-1.56817038e-02						inf						inf			
 1.52081200e-01			7.40594732e-05			4.87827670e-06			3.94411270e+00			-7.27446002e-01						1.47759524e+00							1.26764924e-03					-2.33964404e-04						-1.56426884e-02						inf						inf			
 1.53468700e-01			7.36224784e-05			4.79665990e-06			3.91780674e+00			-7.25084156e-01						1.46655058e+00							1.25954884e-03					-2.33174506e-04						-1.56230240e-02						inf						inf			

--- a/beta=4.7e+04-Am=1-Rm=1.dat
+++ b/beta=4.7e+04-Am=1-Rm=1.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6671e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.32126804e-05			3.53772694e-06			4.27561332e+00			-7.95859166e-01						1.51904096e+00							1.27065684e-03					-2.40572056e-04						-1.36954342e-02						inf						inf			
 1.52081200e-01			5.28461312e-05			3.47871554e-06			4.24983976e+00			-7.90728892e-01						1.50828090e+00							1.26499330e-03					-2.39685486e-04						-1.36603730e-02						inf						inf			
 1.53468700e-01			5.25294872e-05			3.42042326e-06			4.22248992e+00			-7.88243306e-01						1.49697782e+00							1.25651784e-03					-2.38818832e-04						-1.36425914e-02						inf						inf			

--- a/beta=4.7e+04-Am=1-Rm=10.dat
+++ b/beta=4.7e+04-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6704e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			8.24281570e-05			5.48509846e-06			3.74831678e+00			-6.81051066e-01						1.46876700e+00							1.25372522e-03					-2.29218900e-04						-1.61153170e-02						inf						inf			
 1.52081200e-01			8.18994810e-05			5.39852840e-06			3.72535426e+00			-6.76381572e-01						1.45899500e+00							1.24881396e-03					-2.28432160e-04						-1.60761214e-02						inf						inf			
 1.53468700e-01			8.14257756e-05			5.30854240e-06			3.69949604e+00			-6.74111198e-01						1.44809100e+00							1.24082300e-03					-2.27664100e-04						-1.60565762e-02						inf						inf			

--- a/beta=4.7e+04-Am=1-Rm=100.dat
+++ b/beta=4.7e+04-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6806e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.04604084e-04			6.96345390e-06			3.54682066e+00			-6.35693004e-01						1.44773300e+00							1.26730600e-03					-2.27289898e-04						-1.77390574e-02						inf						inf			
 1.52081200e-01			1.03956740e-04			6.85644942e-06			3.52489100e+00			-6.31201654e-01						1.43839700e+00							1.26267678e-03					-2.26541966e-04						-1.76968464e-02						inf						inf			
 1.53468700e-01			1.03368402e-04			6.74279502e-06			3.49954000e+00			-6.29012750e-01						1.42769800e+00							1.25483450e-03					-2.25812404e-04						-1.76759850e-02						inf						inf			

--- a/beta=4.7e+04-Am=1-Rm=inf.dat
+++ b/beta=4.7e+04-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.6896e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.12360456e-04			7.48000406e-06			3.52906794e+00			-6.31839140e-01						1.44585612e+00							1.29656834e-03					-2.31982978e-04						-1.83471308e-02						inf						inf			
 1.52081200e-01			1.11667274e-04			7.36533078e-06			3.50723136e+00			-6.27363616e-01						1.43655986e+00							1.29187174e-03					-2.31224560e-04						-1.83035624e-02						inf						inf			
 1.53468700e-01			1.11036558e-04			7.24330806e-06			3.48193074e+00			-6.25181766e-01						1.42588170e+00							1.28388604e-03					-2.30484864e-04						-1.82820458e-02						inf						inf			

--- a/beta=4.7e+04-Am=2-Rm=inf.dat
+++ b/beta=4.7e+04-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7079e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.75255282e-04			1.16769810e-05			3.16867458e+00			-5.44979666e-01						1.39696750e+00							1.31059592e-03					-2.25269318e-04						-2.18115610e-02						inf						inf			
 1.52081200e-01			1.74265144e-04			1.15087254e-05			3.14859306e+00			-5.40828908e-01						1.38862974e+00							1.30653182e-03					-2.24586788e-04						-2.17617368e-02						inf						inf			
 1.53468700e-01			1.73344680e-04			1.13218934e-05			3.12402724e+00			-5.38793282e-01						1.37851192e+00							1.29894340e-03					-2.23922326e-04						-2.17377288e-02						inf						inf			

--- a/beta=4.7e+04-Am=4-Rm=inf.dat
+++ b/beta=4.7e+04-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7428e+04
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.82150044e-04			1.88101602e-05			2.85414096e+00			-4.72763166e-01						1.33862394e+00							1.29606898e-03					-2.14575700e-04						-2.62165924e-02						inf						inf			
 1.52081200e-01			2.80687492e-04			1.85544502e-05			2.83571176e+00			-4.68920308e-01						1.33119846e+00							1.29266794e-03					-2.13975360e-04						-2.61589298e-02						inf						inf			
 1.53468700e-01			2.79312434e-04			1.82606342e-05			2.81210294e+00			-4.67023820e-01						1.32175718e+00							1.28571764e-03					-2.13392224e-04						-2.61319586e-02						inf						inf			

--- a/beta=4.8e+03-Am=0.25-Rm=inf.dat
+++ b/beta=4.8e+03-Am=0.25-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7767e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.44559500e-04			9.57340622e-06			6.48889534e+00			-1.27212500e+00						1.75884300e+00							3.73287278e-03					-7.34059800e-04						-2.82244000e-02						inf						inf			
 1.52081200e-01			1.43394500e-04			9.39222600e-06			6.45068240e+00			-1.26508700e+00						1.74455400e+00							3.71251894e-03					-7.31257200e-04						-2.81423800e-02						inf						inf			
 1.53468700e-01			1.42493400e-04			9.23735800e-06			6.41618600e+00			-1.26167900e+00						1.73181400e+00							3.68782120e-03					-7.28514800e-04						-2.80993000e-02						inf						inf			

--- a/beta=4.8e+03-Am=0.5-Rm=inf.dat
+++ b/beta=4.8e+03-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7926e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.16507858e-04			1.43531648e-05			5.73588414e+00			-1.11810100e+00						1.66946800e+00							3.74233780e-03					-7.30459524e-04						-3.20680664e-02						inf						inf			
 1.52081200e-01			2.14816030e-04			1.40884320e-05			5.70209700e+00			-1.11172200e+00						1.65631700e+00							3.72286712e-03					-7.27706622e-04						-3.19778194e-02						inf						inf			
 1.53468700e-01			2.13471078e-04			1.38541342e-05			5.67043100e+00			-1.10863500e+00						1.64413400e+00							3.69811394e-03					-7.25013558e-04						-3.19305618e-02						inf						inf			

--- a/beta=4.8e+03-Am=1-Rm=10.dat
+++ b/beta=4.8e+03-Am=1-Rm=10.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.7702e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.63552900e-04			1.74873920e-05			5.22946200e+00			-1.00954500e+00						1.61803300e+00							3.69317500e-03					-7.20997422e-04						-3.36784800e-02						inf						inf			
 1.52081200e-01			2.61557752e-04			1.71731640e-05			5.19853400e+00			-1.00360400e+00						1.60562100e+00							3.67444336e-03					-7.18243322e-04						-3.35864300e-02						inf						inf			
 1.53468700e-01			2.59930356e-04			1.68858800e-05			5.16849100e+00			-1.00073200e+00						1.59369900e+00							3.64953800e-03					-7.15548924e-04						-3.35386200e-02						inf						inf			

--- a/beta=4.8e+03-Am=1-Rm=100.dat
+++ b/beta=4.8e+03-Am=1-Rm=100.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.8118e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.32681300e-04			2.20818800e-05			4.96640400e+00			-9.56235156e-01						1.59048000e+00							3.73445556e-03					-7.19983520e-04						-3.68482400e-02						inf						inf			
 1.52081200e-01			3.30204166e-04			2.16905224e-05			4.93700400e+00			-9.50520200e-01						1.57848700e+00							3.71630836e-03					-7.17318446e-04						-3.67491700e-02						inf						inf			
 1.53468700e-01			3.28157900e-04			2.13268800e-05			4.90792900e+00			-9.47754698e-01						1.56675300e+00							3.69161964e-03					-7.14712344e-04						-3.66977890e-02						inf						inf			

--- a/beta=4.8e+03-Am=1-Rm=inf.dat
+++ b/beta=4.8e+03-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.8200e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.43242020e-04			2.27828728e-05			4.95971740e+00			-9.55098872e-01						1.58979100e+00							3.77643040e-03					-7.27581264e-04						-3.74037834e-02						inf						inf			
 1.52081200e-01			3.40686862e-04			2.23791862e-05			4.93035934e+00			-9.49389752e-01						1.57780820e+00							3.75811468e-03					-7.24893902e-04						-3.73032668e-02						inf						inf			
 1.53468700e-01			3.38575620e-04			2.20039700e-05			4.90131728e+00			-9.46626938e-01						1.56608096e+00							3.73318668e-03					-7.22266076e-04						-3.72511254e-02						inf						inf			

--- a/beta=4.9e+03-Am=2-Rm=inf.dat
+++ b/beta=4.9e+03-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.8747e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			5.90417096e-04			3.92456578e-05			4.17939162e+00			-7.84603888e-01						1.51847012e+00							3.84341492e-03					-7.21728646e-04						-4.53812466e-02						inf						inf			
 1.52081200e-01			5.86351502e-04			3.85924370e-05			4.15426940e+00			-7.79564406e-01						1.50776900e+00							3.82675806e-03					-7.19165982e-04						-4.52667200e-02						inf						inf			
 1.53468700e-01			5.82816916e-04			3.79437420e-05			4.12747686e+00			-7.77121552e-01						1.49646500e+00							3.80173198e-03					-7.16662152e-04						-4.52084182e-02						inf						inf			

--- a/beta=5.0e+02-Am=0.5-Rm=inf.dat
+++ b/beta=5.0e+02-Am=0.5-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=5.0391e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			6.10095300e-04			4.02760000e-05			8.24301300e+00			-1.65266300e+00						1.99100200e+00							1.12613612e-02					-2.28590514e-03						-6.83655206e-02						inf						inf			
 1.52081200e-01			6.04880400e-04			3.94780012e-05			8.19476100e+00			-1.64413000e+00						1.97376100e+00							1.11926700e-02					-2.27669208e-03						-6.81597398e-02						inf						inf			
 1.53468700e-01			6.01029000e-04			3.88377000e-05			8.15406818e+00			-1.64000400e+00						1.95942400e+00							1.11166200e-02					-2.26766954e-03						-6.80515340e-02						inf						inf			

--- a/beta=5.0e+03-Am=4-Rm=inf.dat
+++ b/beta=5.0e+03-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=4.9830e+03
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.08053076e-03			7.19303778e-05			3.51604814e+00			-6.30234364e-01						1.45159800e+00							3.92348044e-03					-7.03581640e-04						-5.70320020e-02						inf						inf			
 1.52081200e-01			1.07387404e-03			7.08294640e-05			3.49426612e+00			-6.25769738e-01						1.44228800e+00							3.90918398e-03					-7.01267798e-04						-5.68972046e-02						inf						inf			
 1.53468700e-01			1.06779910e-03			6.96550860e-05			3.46896116e+00			-6.23593172e-01						1.43156500e+00							3.88483052e-03					-6.99010796e-04						-5.68305646e-02						inf						inf			

--- a/beta=5.1e+02-Am=1-Rm=inf.dat
+++ b/beta=5.1e+02-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=5.1385e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.05649500e-03			6.98611500e-05			6.97050200e+00			-1.39334600e+00						1.82002300e+00							1.11820200e-02					-2.25075500e-03						-8.00150900e-02						inf						inf			
 1.52081200e-01			1.04770500e-03			6.85074800e-05			6.92980300e+00			-1.38594300e+00						1.80478700e+00							1.11170000e-02					-2.24184300e-03						-7.97808200e-02						inf						inf			
 1.53468700e-01			1.04102900e-03			6.73813800e-05			6.89417810e+00			-1.38236800e+00						1.79162100e+00							1.10415700e-02					-2.23311800e-03						-7.96571200e-02						inf						inf			

--- a/beta=5.3e+02-Am=2-Rm=inf.dat
+++ b/beta=5.3e+02-Am=2-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=5.3121e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			1.93398200e-03			1.28133700e-04			5.75671900e+00			-1.13777200e+00						1.68091000e+00							1.12138900e-02					-2.22603500e-03						-9.64670100e-02						inf						inf			
 1.52081200e-01			1.91865900e-03			1.25749700e-04			5.72303500e+00			-1.13140900e+00						1.66751100e+00							1.11533900e-02					-2.21741300e-03						-9.61975300e-02						inf						inf			
 1.53468700e-01			1.90649300e-03			1.23651500e-04			5.69170700e+00			-1.12833800e+00						1.65519300e+00							1.10776300e-02					-2.20897500e-03						-9.60559300e-02						inf						inf			

--- a/beta=5.4e+05-Am=1-Rm=inf.dat
+++ b/beta=5.4e+05-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=5.4052e+05
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.23497196e-05			2.15729724e-06			2.67477256e+00			-4.31996114e-01						1.30493102e+00							3.93237594e-04					-6.34621018e-05						-8.59460118e-03						inf						inf			
 1.52081200e-01			3.21917692e-05			2.12909208e-06			2.65728382e+00			-4.28335370e-01						1.29802274e+00							3.92326622e-04					-6.32950426e-05						-8.57615858e-03						inf						inf			
 1.53468700e-01			3.20426394e-05			2.09599766e-06			2.63421660e+00			-4.26523862e-01						1.28897744e+00							3.90337972e-04					-6.31330704e-05						-8.56771668e-03						inf						inf			

--- a/beta=5.6e+02-Am=4-Rm=inf.dat
+++ b/beta=5.6e+02-Am=4-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=5.6381e+02
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			3.82392274e-03			2.53890922e-04			4.61937276e+00			-8.89350456e-01						1.56979676e+00							1.13479054e-02					-2.19244502e-03						-1.21419442e-01						inf						inf			
 1.52081200e-01			3.79605640e-03			2.49479196e-04			4.59198120e+00			-8.83945664e-01						1.55819034e+00							1.12937062e-02					-2.18428048e-03						-1.21103482e-01						inf						inf			
 1.53468700e-01			3.77249342e-03			2.45271124e-04			4.56411438e+00			-8.81334394e-01						1.54650224e+00							1.12175528e-02					-2.17629638e-03						-1.20940306e-01						inf						inf			

--- a/beta=6.3e+01-Am=1-Rm=inf.dat
+++ b/beta=6.3e+01-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=6.3027e+01
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.62146500e-03			1.72453004e-04			1.04032000e+01			-2.11742500e+00						2.27201000e+00							3.51517000e-02					-7.50124300e-03						-1.68414400e-01						inf						inf			
 1.52081200e-01			2.59811800e-03			1.68932200e-04			1.03425200e+01			-2.10703700e+00						2.25110100e+00							3.49087400e-02					-7.46788100e-03						-1.67903700e-01						inf						inf			
 1.53468700e-01			2.58149300e-03			1.66244200e-04			1.02938900e+01			-2.10200800e+00						2.23461700e+00							3.46584200e-02					-7.43517386e-03						-1.67640600e-01						inf						inf			

--- a/beta=6.8e+06-Am=1-Rm=inf.dat
+++ b/beta=6.8e+06-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=6.7686e+06
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			9.36584244e-06			6.24910530e-07			2.00390986e+00			-2.89932112e-01						1.17630820e+00							1.11805830e-04					-1.61632828e-05						-4.05393742e-03						inf						inf			
 1.52081200e-01			9.33211176e-06			6.18092250e-07			1.99008190e+00			-2.87011310e-01						1.17137334e+00							1.11809588e-04					-1.61321798e-05						-4.04631346e-03						inf						inf			
 1.53468700e-01			9.30095854e-06			6.09428226e-07			1.96946276e+00			-2.85550020e-01						1.16406326e+00							1.11401840e-04					-1.61027538e-05						-4.04321142e-03						inf						inf			

--- a/beta=8.5e+07-Am=1-Rm=inf.dat
+++ b/beta=8.5e+07-Am=1-Rm=inf.dat
@@ -4,7 +4,7 @@ USE THIS DATA AT YOUR OWN RISK. This data  provided as is, without guarantee of 
 The fields are computed at a spherical radius r=1, and are sampled along the colatitude theta.
 This dataset was computed for plasma beta=8.4823e+07
 
-theta (colatitude)	rho (mass density)	P (thermal press)	 vr (radial velocity)	 vtheta (col velocity)	 vphi (azimuthal velocity)	 Br (radial mag field)	 Btheta (col mag field)	 Bphi (azimuthal mag field)	 Lambda_A (ambipolar number)	 Rm (Ohmic number
+theta (colatitude)	rho (mass density)	P (thermal press)	vr (radial velocity)	vtheta (col velocity)	vphi (azimuthal velocity)	Br (radial mag field)	Btheta (col mag field)	Bphi (azimuthal mag field)	Lambda_A (ambipolar number)	Rm (Ohmic number)
 1.50693700e-01			2.94258638e-06			1.96297232e-07			1.47131846e+00			-1.87016798e-01						1.06660290e+00							3.20870782e-05					-4.07655064e-06						-2.00988486e-03						inf						inf			
 1.52081200e-01			2.93595328e-06			1.94570212e-07			1.46057104e+00			-1.84753616e-01						1.06332252e+00							3.21016874e-05					-4.07264212e-06						-2.00669918e-03						inf						inf			
 1.53468700e-01			2.93109748e-06			1.92241336e-07			1.44246128e+00			-1.83618784e-01						1.05783090e+00							3.20425828e-05					-4.06917528e-06						-2.00560794e-03						inf						inf			


### PR DESCRIPTION
Normalize datafile headers (column names) so that they are easy to parse with pandas:
- fix a missing ')' in the last column name
- enforce tabs as the only separator  (not spaces)


Here's an example
```python
import pandas as pd

file =  "beta=8.5e+07-Am=1-Rm=inf.dat"
df = pd.read_csv(file, skiprows=range(6), sep="\t+", engine="python")
list(df.columns)
```

```
# before
['theta (colatitude)',
 'rho (mass density)',
 'P (thermal press)',
 ' vr (radial velocity)',
 ' vtheta (col velocity)',
 ' vphi (azimuthal velocity)',
 ' Br (radial mag field)',
 ' Btheta (col mag field)',
 ' Bphi (azimuthal mag field)',
 ' Lambda_A (ambipolar number)',
 ' Rm (Ohmic number']

#after
['theta (colatitude)',
 'rho (mass density)',
 'P (thermal press)',
 'vr (radial velocity)',
 'vtheta (col velocity)',
 'vphi (azimuthal velocity)',
 'Br (radial mag field)',
 'Btheta (col mag field)',
 'Bphi (azimuthal mag field)',
 'Lambda_A (ambipolar number)',
 'Rm (Ohmic number)']
```